### PR TITLE
Use the compiler provided by google-closure-compiler, if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,23 @@ bin/$(OUTFILE):
 	cd "bin" && javac "NailgunTest.java" && gcc "NailgunTest.c" -shared -o $(OUTFILE) $(CCFLAGS)
 
 closure-compiler:
-# Init bootstraping
+	mkdir "closure-compiler"
+
+# Use the compiler provide by google-closure-compiler, if available
+ifneq ("$(wildcard ../google-closure-compiler/compiler.jar)","")
+	cp "../google-closure-compiler/compiler.jar" "./closure-compiler/compiler.jar"
+
+else
+# Else, init bootstraping
 	rm -fr "tmp"; mkdir -p "tmp/closure-compiler"
 # Download latest Google Closure Compiler
 	curl -L -o "./tmp/compiler-latest.tgz" "https://dl.google.com/closure-compiler/compiler-latest.tar.gz" \
 		&& tar -xf "./tmp/compiler-latest.tgz" -C "./tmp/closure-compiler"
 # Move compiler.jar
-	mkdir "closure-compiler"
 	mv ./tmp/closure-compiler/closure-compiler-*.jar "./closure-compiler/compiler.jar"
 # Cleanup
 	rm -fr "tmp"
+endif
 
 nailgun:
 # Init bootstraping

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "install": "make install"
   },
-  "dependencies": {
-    "google-closure-compiler": "^20160822.1.0"
+  "peerDependencies": {
+    "google-closure-compiler": ">=20160822.1.0"
   }
 }


### PR DESCRIPTION
I have updated the package.json to be compatible with any version the library consumer chooses to use. The Makefile will now try to reuse this version - failing that, it will grab the latest version, as before.

Also, could you give me an update on whether you are maintaining this package and what its relationship with closure-gun is? @teppeis @denji